### PR TITLE
Use the broadcaster to deliver msgs if espresso mode is on

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -218,6 +218,16 @@ function writeConfigs(argv: any) {
 					"url": argv.validationNodeUrl,
 					"jwtsecret": valJwtSecret,
 				}
+            },
+            "feed": {
+                "input": {
+                    "url": [], // websocket urls
+                },
+                "output": {
+                    "enable": false,
+                    "signed": false,
+                    "addr": "0.0.0.0",
+                },
             }
         },
         "persistent": {
@@ -255,6 +265,7 @@ function writeConfigs(argv: any) {
         sequencerConfig.node.espresso = true
         sequencerConfig.execution.sequencer.espresso = true
         sequencerConfig.execution.sequencer["hotshot-url"] = argv.espressoUrl
+        sequencerConfig.node.feed.output.enable = true
     } else {
         sequencerConfig.node["seq-coordinator"].enable = true
     }
@@ -262,7 +273,11 @@ function writeConfigs(argv: any) {
 
     let posterConfig = JSON.parse(baseConfJSON)
     posterConfig["parent-chain"].wallet.account = namedAccount("sequencer").address
-    posterConfig.node["seq-coordinator"].enable = true
+    if (argv.espresso) {
+        posterConfig.node.feed.input.url.push("ws://sequencer:9642")
+    } else {
+        posterConfig.node["seq-coordinator"].enable = true
+    }
     posterConfig.node["batch-poster"].enable = true
     fs.writeFileSync(path.join(consts.configpath, "poster_config.json"), JSON.stringify(posterConfig))
 


### PR DESCRIPTION
In the original mode, testnode uses the sequencer coordinator to pass messages. When espresso mode is enabled, we no longer use the sequencer coordinator, so we activate the broadcaster.