### PR TITLE
Add eth RPC to validation node

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -277,7 +277,7 @@ services:
       - "validator-data:/home/user/.arbitrum/local/nitro"
       - "l1keystore:/home/user/l1keystore"
       - "config:/config"
-    command: --conf.file /config/validator_config.json --http.port 8547 --http.api net,web3,arb,debug --ws.port 8548
+    command: --conf.file /config/validator_config.json --http.port 8547 --http.api net,web3,arb,debug,net,eth --ws.port 8548
     depends_on:
       - sequencer
       - validation_node


### PR DESCRIPTION
@sveitser this should effectively enable the "slow" confirmation path - the validator will now expose an eth RPC based on validated message batches