### PR TITLE
Consistent use of docker compose

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -346,22 +346,22 @@ if $force_init; then
     fi
 
     echo == Funding validator, sequencer and l2owner
-    docker-compose run scripts send-l1 --ethamount 1000 --to validator --wait
-    docker-compose run scripts send-l1 --ethamount 1000 --to sequencer --wait
+    docker compose run scripts send-l1 --ethamount 1000 --to validator --wait
+    docker compose run scripts send-l1 --ethamount 1000 --to sequencer --wait
     docker compose run scripts send-l1 --ethamount 1000 --to l2owner --wait
-    docker-compose run scripts send-l1 --ethamount 1000 --to espresso-sequencer --wait
+    docker compose run scripts send-l1 --ethamount 1000 --to espresso-sequencer --wait
 
     echo == create l1 traffic
-    docker-compose run scripts send-l1 --ethamount 1000 --to user_l1user --wait
-    docker-compose run scripts send-l1 --ethamount 0.0001 --from user_l1user --to user_l1user_b --wait --delay 500 --times 1000000 > /dev/null &
+    docker compose run scripts send-l1 --ethamount 1000 --to user_l1user --wait
+    docker compose run scripts send-l1 --ethamount 0.0001 --from user_l1user --to user_l1user_b --wait --delay 500 --times 1000000 > /dev/null &
 
     echo == Writing l2 chain config
-    docker-compose run scripts write-l2-chain-config --espresso $espresso
+    docker compose run scripts write-l2-chain-config --espresso $espresso
 
     if $espresso; then
         echo == Deploying Espresso Contract
         echo "" > espresso.env
-        docker-compose up -d commitment-task espresso-sequencer0 espresso-sequencer1 --wait
+        docker compose up -d commitment-task espresso-sequencer0 espresso-sequencer1 --wait
         hotShotAddr=`curl http://localhost:60000/api/hotshot_contract`
         echo "ESPRESSO_SEQUENCER_HOTSHOT_ADDRESS=$hotShotAddr" > espresso.env
     fi


### PR DESCRIPTION
`docker compose` is used everywhere except these few lines where we switch to `docker-compose`. This PR just cleans that up so the same command is called everywhere. 