### PR TITLE
Misc small testnode fixes

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -180,7 +180,6 @@ function writeConfigs(argv: any) {
                 "strategy": "MakeNodes",
             },
             "sequencer": false,
-            "espresso": false,
             "dangerous": {
                 "no-sequencer-coordinator": false,
                 "disable-blob-reader": true,
@@ -247,7 +246,8 @@ function writeConfigs(argv: any) {
             "forwarding-target": "null",
         },
         "persistent": {
-            "chain": "local"
+            "chain": "local",
+            "db-engine": "leveldb"
         },
         "ws": {
             "addr": "0.0.0.0"
@@ -296,7 +296,6 @@ function writeConfigs(argv: any) {
         sequencerConfig.node["delayed-sequencer"].enable = true
 
         if (argv.espresso) {
-            sequencerConfig.node.espresso = true
             sequencerConfig.execution.sequencer.espresso = true
             sequencerConfig.execution.sequencer["hotshot-url"] = argv.espressoUrl
             sequencerConfig.node.feed.output.enable = true

--- a/test-node.bash
+++ b/test-node.bash
@@ -6,7 +6,7 @@ NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.0.1-cf4b74e-dev
 ESPRESSO_VERSION=ghcr.io/espressosystems/nitro-espresso-integration/nitro-node-dev:integration
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.0.0-c8db5b1
 
-DEFAULT_NITRO_CONTRACTS_VERSION="deploy"
+DEFAULT_NITRO_CONTRACTS_VERSION="develop"
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"
 
 # Set default versions if not overriden by provided env vars
@@ -301,7 +301,7 @@ if $force_build; then
         echo execute from a sub-directory of nitro or use NITRO_SRC environment variable
         exit 1
     fi
-    docker build "$NITRO_SRC" -t nitro-node-dev --target nitro-node-dev -f
+    docker build "$NITRO_SRC" -t nitro-node-dev --target nitro-node-dev
   fi
   if $dev_build_blockscout; then
     if $blockscout; then


### PR DESCRIPTION
Close https://github.com/EspressoSystems/nitro-espresso-integration/issues/185

- Use `develop` branch of nitro-contracts, the branch we develop on
- Remove `node.espresso` argument that was removed in nitro
- Remove trailing `-f` argument from docker build command
- Default to `leveldb` db backend to avoid panic from new default backend `pebble`.