### PR TITLE
Cloning with git URL fails inside docker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
         url = https://github.com/OffchainLabs/blockscout.git
 [submodule "orbit-actions"]
 	path = orbit-actions
-	url = git@github.com:EspressoSystems/orbit-actions.git
+	url = https://github.com/EspressoSystems/orbit-actions.git
 	branch = integration


### PR DESCRIPTION
Causes our nitro docker build to fail

https://github.com/EspressoSystems/nitro-espresso-integration/actions/runs/11727749989/job/32669575639

Switch to https URL