### PR TITLE
Download srs file first

### DIFF
--- a/Dockerfile.sgx-poster
+++ b/Dockerfile.sgx-poster
@@ -2,10 +2,10 @@ FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node-dev:20241124-
 
 COPY ./config /config/
 COPY ./l1keystore /l1keystore/
-RUN curl -L -o kzg10-aztec20-srs-1024.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1024.bin
+RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
 
 EXPOSE 8547
 EXPOSE 8548
 
-ENV AZTEC_SRS_PATH=/home/user/kzg10-aztec20-srs-1024.bin
+ENV AZTEC_SRS_PATH=/home/user/kzg10-aztec20-srs-1048584.bin
 ENTRYPOINT ["env", "HOME=/home/user", "/usr/local/bin/nitro", "--validation.wasm.enable-wasmroots-check=false", "--conf.file", "/config/poster_config.json"]

--- a/Dockerfile.sgx-poster
+++ b/Dockerfile.sgx-poster
@@ -2,8 +2,10 @@ FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node-dev:20241124-
 
 COPY ./config /config/
 COPY ./l1keystore /l1keystore/
+RUN curl -L -o kzg10-aztec20-srs-1024.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1024.bin
 
 EXPOSE 8547
 EXPOSE 8548
 
-ENTRYPOINT ["env", "HOME=/home/user", "/usr/local/bin/nitro", "--validation.wasm.enable-wasmroots-check=false", "--conf.file", "/config/poster_config.json"] 
+ENV AZTEC_SRS_PATH=/home/user/kzg10-aztec20-srs-1024.bin
+ENTRYPOINT ["env", "HOME=/home/user", "/usr/local/bin/nitro", "--validation.wasm.enable-wasmroots-check=false", "--conf.file", "/config/poster_config.json"]


### PR DESCRIPTION
### This PR:
Download the srs file when building the docker image.

In this [repo](https://github.com/alxiong/ark-srs), srs files are downloaded to a random temporary path first.

https://github.com/alxiong/ark-srs/blob/8ae41e79b7a209abc3855179e7c6fc885bb4680a/src/load.rs#L57C1-L75C2

Thus, it is impossible for us to add it to the `allowed_files` in sgx manifest.

### How to test this PR
With this sgx manifest
```
sys.enable_sigterm_injection = true
sys.enable_extra_runtime_domain_names_conf = true

sgx.nonpie_binary = true
sgx.enclave_size = "16G"
sgx.edmm_enable = true
sgx.remote_attestation = "dcap"
sys.experimental__enable_flock = true
sgx.use_exinfo = true

############################# SGX: ALLOWED FILES ###############################
sgx.allowed_files = ["file:/home/user/.arbitrum", "file:/home/user/kzg10-aztec20-srs-1024.bin"]
```

to see if the batch poster can work in SGX environment.
