### PR TITLE
Add backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,18 @@
+# Create a backport PR to branch "foo" from a merged PR by adding a PR label "backport foo"
+name: Backport merged pull request
+on:
+  pull_request_target:
+    types: [closed]
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+    # Don't run on closed unmerged pull requests
+    if: github.event.pull_request.merged
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v3


### PR DESCRIPTION
This action is useful to make backport PRs if changes need to 
go into multiple branches. Since we maintain both `integration`
and `celestia-integration` branches I think it should be useful in
this repo and help reduce cognitive load and errors from manual
backporting to a certain degree.