### PR TITLE
WIP: run batch poster with memory db and message pruner

### DIFF
--- a/run-memory-db-poster.bash
+++ b/run-memory-db-poster.bash
@@ -1,0 +1,3 @@
+./test-node.bash --init-force --espresso --latest-espresso-image --batch-poster-memory-db --validate --detach
+
+# ./test-node.bash --espresso --latest-espresso-image --batch-poster-memory-db --batchposters 1 --detach

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -258,6 +258,11 @@ function writeConfigs(argv: any) {
         },
         dangerous: { "reset-block-validation": false },
       },
+      "message-pruner": {
+        enable: false,
+        "prune-interval": "10s",
+        "min-batches-left": 1,
+      },
       feed: {
         input: {
           url: [], // websocket urls
@@ -440,6 +445,12 @@ function writeConfigs(argv: any) {
       posterConfig.node["batch-poster"]["hotshot-url"] = argv.espressoUrl;
       posterConfig.node["batch-poster"]["light-client-address"] =
         argv.lightClientAddress;
+      if (argv.batchPosterMemoryDb) {
+        posterConfig.node["message-pruner"]["enable"] = true;
+        // I know here is confusing. The chain name will be set to the data directory.
+        // Using an empty string to ask the db engine to use memory database.
+        posterConfig["persistent"]["chain"] = "";
+      }
     } else {
       posterConfig.node["seq-coordinator"].enable = true;
     }

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -42,6 +42,7 @@ async function main() {
       lightClientAddress: { string: true, description: 'address of the light client contract', default: ''},
       enableCaffNode: {boolean: true, description: 'enable caff node', default: false},
       simpleWithValidator: {boolean: true, description: 'start a simple node that validates', default: false},
+      batchPosterMemoryDb: {boolean: true, description: 'enable batch poster memory db', default: false},
     })
     .command(bridgeFundsCommand)
     .command(bridgeToL3Command)

--- a/test-node.bash
+++ b/test-node.bash
@@ -10,7 +10,7 @@ BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 DEFAULT_NITRO_CONTRACTS_VERSION="99c07a7db2fcce75b751c5a2bd4936e898cda065"
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"
 
-ESPRESSO_VERSION=ghcr.io/espressosystems/nitro-espresso-integration/nitro-node-dev:integration
+ESPRESSO_VERSION=ghcr.io/espressosystems/nitro-espresso-integration/nitro-node-dev:jh-memory-db
 
 # Set default versions if not overriden by provided env vars
 : ${NITRO_CONTRACTS_REPO:=$DEFAULT_NITRO_CONTRACTS_REPO}
@@ -75,6 +75,8 @@ build_utils=false
 force_build_utils=false
 build_node_images=false
 
+batch_poster_memory_db=false
+
 while [[ $# -gt 0 ]]; do
     case $1 in
         --init)
@@ -131,6 +133,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --latest-espresso-image)
             latest_espresso_image=true
+            shift
+            ;;
+        --batch-poster-memory-db)
+            batch_poster_memory_db=true
             shift
             ;;
         --build)
@@ -557,10 +563,10 @@ if $force_init; then
 
     else
         echo == Writing configs
-        docker compose run scripts write-config  $anytrustNodeConfigLine --espresso $l2_espresso --lightClientAddress $lightClientAddr
+        docker compose run scripts write-config  $anytrustNodeConfigLine --espresso $l2_espresso --lightClientAddress $lightClientAddr --batchPosterMemoryDb $batch_poster_memory_db
         if $enableCaffNode; then
             echo == Writing configs for finality node
-            docker compose run scripts write-config  $anytrustNodeConfigLine  --espresso $l2_espresso  --enableCaffNode --lightClientAddress $lightClientAddr
+            docker compose run scripts write-config  $anytrustNodeConfigLine  --espresso $l2_espresso  --enableCaffNode --lightClientAddress $lightClientAddr --batchPosterMemoryDb $batch_poster_memory_db
         fi
         echo == Initializing redis
         docker compose up --wait redis


### PR DESCRIPTION
`run-memory-db-poster.bash` should run nodes and a batch poster with message pruner and memory db.

Haven't found a way to test it though