### PR TITLE
Caff node delayed message test

### DIFF
--- a/mock-sequencer/index.ts
+++ b/mock-sequencer/index.ts
@@ -35,6 +35,12 @@ app.post('/reset', (_req, res) => {
   res.json(sequencer.getCurrentCount())
 })
 
+app.post('/send-invalid-delayed-messages', (_req, res) => {
+  const count = sequencer.getCurrentCount()
+  sequencer.setSendInvalidDelayedMessages()
+  res.json(count)
+})
+
 app.listen(HTTP_PORT, () => {
   console.log(`MockSequencer HTTP server listening on http://localhost:${HTTP_PORT}`)
 })

--- a/mock-sequencer/wss.ts
+++ b/mock-sequencer/wss.ts
@@ -13,6 +13,12 @@ export class MockSequencer {
                 this.clients.delete(ws)
             })
         })
+        this.wss.on('message', (data) => {
+            console.log('receive message:', data)
+            if (this.remoteWs) {
+                this.remoteWs.send(data)
+            }
+        })
 
     }
 
@@ -34,10 +40,16 @@ export class MockSequencer {
         this.sendOversized = this.getCurrentCount() + 1
     }
 
+    public setSendInvalidDelayedMessages() {
+        console.log('setting next block to be invalid delayed messages', this.getCurrentCount() + 1)
+        this.sendInvalidDelayedMessages = true
+    }
+
     public reset() {
         this.skipNext = 0
         this.sendInRandom = false
         this.sendOversized = 0
+        this.sendInvalidDelayedMessages = false
     }
 
     private processAndBroadcast(data: WebSocket.Data) {
@@ -50,6 +62,9 @@ export class MockSequencer {
         let intercept = false
         messages.messages.forEach((message) => {
             const blockNumber = message.sequenceNumber
+            const delayedCount = message.message.delayedMessagesRead
+            this.blockNumberToDelayedCount.set(blockNumber, delayedCount)
+
             if (blockNumber == this.skipNext) {
                 console.log('Skipping block', blockNumber)
                 intercept = true
@@ -61,15 +76,30 @@ export class MockSequencer {
                 const l2MsgBytes = new TextEncoder().encode(overSized)
                 console.log("oversized message length:", l2MsgBytes.length)
                 message.message.message.l2Msg = overSized
-                return
             }
-            newMessages.push(message)
+
+            if (this.sendInvalidDelayedMessages) {
+                const previousDelayedCount = this.blockNumberToDelayedCount.get(blockNumber - 1)
+                if (previousDelayedCount === undefined) {
+                    // we don't know if this is a delayed message, will skip it first
+                    return
+                }
+                if (previousDelayedCount + 1 === delayedCount) {
+                    console.log('tampering delayed messages', delayedCount)
+                    message.message.message.l2Msg = ''
+                    intercept = true
+                }
+            }
+
             if (blockNumber > this.blockNumber) {
                 this.blockNumber = blockNumber
             }
+            newMessages.push(message)
         })
 
-        if (this.skipNext === null && this.sendOversized === null) {
+        if (!this.skipNext &&
+            !this.sendOversized &&
+            !this.sendInvalidDelayedMessages) {
             return this.broadcastToClients(data)
         }
         if (intercept) {
@@ -113,10 +143,6 @@ export class MockSequencer {
             console.error('Remote WebSocket error:', err)
         })
 
-        this.wss.on('message', (data) => {
-            console.log('receive message:', data)
-            this.remoteWs.send(data)
-        })
     }
 
     private broadcastToClients(data: WebSocket.Data) {
@@ -135,8 +161,10 @@ export class MockSequencer {
     private wss: WebSocketServer
     private remoteWs!: WebSocket
     private blockNumber = 0
+    private blockNumberToDelayedCount = new Map<number, number>([[0, 1]])
 
     private skipNext: number | null = null
     private sendInRandom = false
     private sendOversized: number | null = null
+    private sendInvalidDelayedMessages = false
 }

--- a/regression-tests/batcher-with-malicious-sequencer.bash
+++ b/regression-tests/batcher-with-malicious-sequencer.bash
@@ -54,10 +54,6 @@ echo "starting with mock sequencer"
 
 ../test-node.bash --init-force --espresso --latest-espresso-image --validate --mock-sequencer --detach
 
-export http_proxy=""
-export https_proxy=""
-export all_proxy=""
-
 while true; do
     curl -sfL http://localhost:41000/v0/status/block-height && break || sleep 5
     echo "waiting for nodes"

--- a/regression-tests/batcher-with-malicious-sequencer.bash
+++ b/regression-tests/batcher-with-malicious-sequencer.bash
@@ -54,6 +54,10 @@ echo "starting with mock sequencer"
 
 ../test-node.bash --init-force --espresso --latest-espresso-image --validate --mock-sequencer --detach
 
+export http_proxy=""
+export https_proxy=""
+export all_proxy=""
+
 while true; do
     curl -sfL http://localhost:41000/v0/status/block-height && break || sleep 5
     echo "waiting for nodes"

--- a/regression-tests/caff-node-delayed-message.bash
+++ b/regression-tests/caff-node-delayed-message.bash
@@ -6,9 +6,28 @@ cd "$(dirname "$0")"
 echo "starting nodes"
 ../test-node.bash --init-force --espresso --no-simple --latest-espresso-image --caff-node --mock-sequencer --detach
 
-export http_proxy=""
-export https_proxy=""
-export all_proxy=""
+send_delayed_transaction_and_wait() {
+    local user=$1
+    local address=$(docker compose run scripts print-address --account $user | tail -n 1 | tr -d '\r\n')
+    local beforeBalance=$(cast balance $address --rpc-url http://127.0.0.1:8550)
+
+    if [ "$beforeBalance" != "0" ]; then
+        echo "failed to get balance for user $user"
+        exit 1
+    fi
+
+    docker compose run scripts send-l2-delayed --ethamount 10000 --to $user --wait
+
+    while true; do
+        echo "checking balance through the caff node"
+        balance=$(cast balance $address --rpc-url http://127.0.0.1:8550)
+        echo "balance: $balance"
+        if [ -n "$balance" ] && [ "$(echo "$balance > 0" | bc)" -eq 1 ]; then
+            break
+        fi
+        sleep 1
+    done
+}
 
 echo "starting tx spammer"
 docker compose run --detach scripts send-l2 --ethamount 10 --to user_l2user --times 500000 --delay 20000 --wait
@@ -18,34 +37,38 @@ sleep 10
 curl -X POST --fail --silent http://127.0.0.1:10000/send-invalid-delayed-messages
 sleep 5
 
-user=user_delayed_user
-address=$(docker compose run scripts print-address --account $user | tail -n 1 | tr -d '\r\n')
-beforeBalance=$(cast balance $address --rpc-url http://127.0.0.1:8550)
-
-if [ "$beforeBalance" != "0" ]; then
-    echo "failed to get balance for user $user"
-    exit 1
-fi
-
 beforeL1=$(cast block-number --rpc-url http://127.0.0.1:8545)
 echo "before sending delayed transaction, l1 block number: $beforeL1"
-docker compose run scripts send-l2-delayed --ethamount 10000 --to $user --wait
-
-while true; do
-    echo "checking balance through the caff node"
-    balance=$(cast balance $address --rpc-url http://127.0.0.1:8550)
-    echo "balance: $balance"
-    if [ -n "$balance" ] && [ "$(echo "$balance > 0" | bc)" -eq 1 ]; then
-        break
-    fi
-    sleep 1
-done
+send_delayed_transaction_and_wait user_delayed_user
 
 finalizedL1=$(cast block-number finalized --rpc-url http://127.0.0.1:8545)
 echo "after getting delayed message, finalized block number: $finalizedL1"
 
 if [ "$finalizedL1" -lt "$beforeL1" ]; then
     echo "delayed transaction get included before block being finalized"
+    exit 1
+fi
+
+sleep 5
+
+requiredBlockDepth=64
+docker compose run scripts update-config-value --path /config/caff_sequencer_config.json --property node.espresso-caff-node.wait-for-finalization --value false --isBool true
+docker compose run scripts update-config-value --path /config/caff_sequencer_config.json --property node.espresso-caff-node.wait-for-confirmations --value true --isBool true
+docker compose run scripts update-config-value --path /config/caff_sequencer_config.json --property node.espresso-caff-node.required-block-depth --value $requiredBlockDepth --isNumber true
+
+docker compose restart caff-node
+sleep 10
+
+beforeL1=$(cast block-number --rpc-url http://127.0.0.1:8545)
+echo "before sending delayed transaction, l1 block number: $beforeL1"
+send_delayed_transaction_and_wait user_delayed_user_2
+
+latestBlock=$(cast block-number --rpc-url http://127.0.0.1:8545)
+if [ "$latestBlock" -lt $((beforeL1+requiredBlockDepth)) ]; then
+    echo "delayed transaction get included before block being finalized"
+    echo "latest block: $latestBlock"
+    echo "require block depth: $requireBlockDepth"
+    echo "beforeL1: $beforeL1"
     exit 1
 fi
 

--- a/regression-tests/caff-node-delayed-message.bash
+++ b/regression-tests/caff-node-delayed-message.bash
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "starting nodes"
+../test-node.bash --init-force --espresso --no-simple --latest-espresso-image --caff-node --mock-sequencer --detach
+
+echo "starting tx spammer"
+docker compose run --detach scripts send-l2 --ethamount 10 --to user_l2user --times 500000 --delay 20000 --wait
+
+sleep 10
+
+curl -X POST --fail --silent http://127.0.0.1:10000/send-invalid-delayed-messages
+sleep 5
+
+user=user_delayed_user
+address=$(docker compose run scripts print-address --account $user | tail -n 1 | tr -d '\r\n')
+beforeBalance=$(cast balance $address --rpc-url http://127.0.0.1:8550)
+
+if [ "$beforeBalance" != "0" ]; then
+    echo "failed to get balance for user $user"
+    exit 1
+fi
+
+docker compose run scripts send-l2-delayed --ethamount 10000 --to $user --wait
+
+while true; do
+    echo "checking balance through the caff node"
+    balance=$(cast balance $address --rpc-url http://127.0.0.1:8550)
+    echo "balance: $balance"
+    if [ -n "$balance" ] && [ "$(echo "$balance > 0" | bc)" -eq 1 ]; then
+        break
+    fi
+    sleep 1
+done
+
+docker compose down

--- a/regression-tests/caff-node-delayed-message.bash
+++ b/regression-tests/caff-node-delayed-message.bash
@@ -6,6 +6,10 @@ cd "$(dirname "$0")"
 echo "starting nodes"
 ../test-node.bash --init-force --espresso --no-simple --latest-espresso-image --caff-node --mock-sequencer --detach
 
+export http_proxy=""
+export https_proxy=""
+export all_proxy=""
+
 echo "starting tx spammer"
 docker compose run --detach scripts send-l2 --ethamount 10 --to user_l2user --times 500000 --delay 20000 --wait
 
@@ -23,6 +27,8 @@ if [ "$beforeBalance" != "0" ]; then
     exit 1
 fi
 
+beforeL1=$(cast block-number --rpc-url http://127.0.0.1:8545)
+echo "before sending delayed transaction, l1 block number: $beforeL1"
 docker compose run scripts send-l2-delayed --ethamount 10000 --to $user --wait
 
 while true; do
@@ -34,5 +40,13 @@ while true; do
     fi
     sleep 1
 done
+
+finalizedL1=$(cast block-number finalized --rpc-url http://127.0.0.1:8545)
+echo "after getting delayed message, finalized block number: $finalizedL1"
+
+if [ "$finalizedL1" -lt "$beforeL1" ]; then
+    echo "delayed transaction get included before block being finalized"
+    exit 1
+fi
 
 docker compose down

--- a/regression-tests/caff-node-restart.bash
+++ b/regression-tests/caff-node-restart.bash
@@ -124,4 +124,3 @@ if [[ $next_processing_hotshot_block_num -le $((last_processing_hotshot_block_nu
 fi
 
 exit 1
-

--- a/regression-tests/caff-node-restart.bash
+++ b/regression-tests/caff-node-restart.bash
@@ -49,10 +49,6 @@ echo "starting nodes"
 
 ../test-node.bash --init-force --espresso --no-simple --latest-espresso-image --caff-node $l3_arg --detach
 
-export http_proxy=""
-export https_proxy=""
-export all_proxy=""
-
 container_name="caff-node"
 
 while true; do

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -183,6 +183,32 @@ function getChainInfo(): ChainInfo {
   return chainInfo;
 }
 
+function updateConfigValue(argv: any) {
+  const filePath = argv.path
+  const propertyPath = argv.property
+  const value = argv.value
+  let v: any
+  if (argv.isBool) {
+    v = value === "true" ? true : false
+  } else if (argv.isNumber) {
+    v = Number(value)
+  } else {
+    v = value
+  }
+  const fileContents = fs.readFileSync(filePath).toString();
+  const config = JSON.parse(fileContents);
+  const property = propertyPath.split(".");
+  let current = config;
+  for (let i = 0; i < property.length - 1; i++) {
+    if (!current[property[i]]) {
+      throw new Error(`Property ${property[i]} not found`);
+    }
+    current = current[property[i]];
+  }
+  current[property[property.length - 1]] = v;
+  fs.writeFileSync(filePath, JSON.stringify(config, null, 2));
+}
+
 function writeConfigs(argv: any) {
   const valJwtSecret = path.join(consts.configpath, "val_jwt.hex");
   const chainInfoFile = path.join(consts.configpath, "l2_chain_info.json");
@@ -729,6 +755,39 @@ function dasBackendsJsonConfig(argv: any) {
     ],
   };
   return backends;
+}
+
+export const updateConfigValueCommand = {
+  command: "update-config-value",
+  describe: "updates a config value",
+  builder: {
+    path: {
+      string: true,
+      describe: "path to config file",
+      default: "l2_chain_info.json",
+    },
+    property: {
+      string: true,
+      describe: "property to update",
+    },
+    value: {
+      string: true,
+      describe: "value to set",
+    },
+    isBool: {
+      boolean: true,
+      describe: "value is boolean",
+      default: false,
+    },
+    isNumber: {
+      boolean: true,
+      describe: "value is number",
+      default: false,
+    },
+  },
+  handler: async (argv: any) => {
+    updateConfigValue(argv)
+  },
 }
 
 export const writeConfigCommand = {

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -427,8 +427,8 @@ function writeConfigs(argv: any) {
         "legacy-sgx-verifier-addr":
           "0xb562622f2D76F355D673560CB88c1dF6088702f1",
         "batch-poster-addr": "0xe2148eE53c0755215Df69b2616E552154EdC584f",
-        "wait-for-finalization": false,
-        "wait-for-confirmations": true,
+        "wait-for-finalization": true,
+        "wait-for-confirmations": false,
         "blocks-to-read": 6,
         "force-inclusion-checker": {
           "block-threshold-tolerance": 1,

--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -55,6 +55,44 @@ async function bridgeFunds(argv: any, parentChainUrl: string, chainUrl: string, 
   }
 }
 
+async function sendL2DelayedTransaction(argv: any, parentChainUrl: string, chainUrl: string, inboxAddr: string) {
+  const l2provider = new ethers.providers.WebSocketProvider(chainUrl);
+  const account = namedAccount(argv.from, argv.threadId).connect(l2provider)
+  const startNonce = await account.getTransactionCount("pending")
+  argv.data = undefined
+  const tx = await account.populateTransaction({
+    to: namedAddress(argv.to, argv.threadId),
+    value: ethers.utils.parseEther(argv.ethamount),
+    data: argv.data,
+    nonce: startNonce,
+  })
+  const signedTx = await account.signTransaction(tx)
+  // signed transaction type is 4
+  const txBytes = [4, ...ethers.utils.arrayify(signedTx)]
+  const dataStr = ethers.utils.hexlify(txBytes)
+  const iface = new ethers.utils.Interface([
+    "function sendL2Message(bytes messageData)"
+  ]);
+  const data = iface.encodeFunctionData("sendL2Message", [dataStr]);
+
+  argv.provider = new ethers.providers.WebSocketProvider(parentChainUrl);
+  argv.data = data
+  const l1provider = new ethers.providers.WebSocketProvider(parentChainUrl);
+  const l1Account = namedAccount("funnel", argv.threadId).connect(l1provider)
+  const nonce = await l1Account.getTransactionCount("pending")
+  const response = await l1Account.sendTransaction({
+    to: inboxAddr,
+    value: 0,
+    data: argv.data,
+    nonce: nonce,
+  })
+  if (argv.wait) {
+    const receipt = await response.wait()
+    console.log(receipt)
+  }
+  l1provider.destroy()
+}
+
 async function bridgeNativeToken(argv: any, parentChainUrl: string, chainUrl: string, inboxAddr: string, token: string) {
   argv.provider = new ethers.providers.WebSocketProvider(parentChainUrl);
 
@@ -492,6 +530,44 @@ export const sendL2Command = {
     await runStress(argv, sendTransaction);
 
     argv.provider.destroy();
+  },
+};
+
+export const sendL2DelayedCommand = {
+  command: "send-l2-delayed",
+  describe: "sends funds between l2 accounts using delayed inbox",
+  builder: {
+    ethamount: {
+      string: true,
+      describe: "amount to transfer (in eth)",
+      default: "10",
+    },
+    from: {
+      string: true,
+      describe: "account (see general help)",
+      default: "funnel",
+    },
+    to: {
+      string: true,
+      describe: "address (see general help)",
+      default: "funnel",
+    },
+    wait: {
+      boolean: true,
+      describe: "wait for transaction to complete",
+      default: false,
+    },
+    data: { string: true, describe: "data" },
+  },
+  handler: async (argv: any) => {
+    const deploydata = JSON.parse(
+      fs
+        .readFileSync(path.join(consts.configpath, "deployment.json"))
+        .toString()
+    );
+    const inboxAddr = ethers.utils.hexlify(deploydata.inbox);
+    console.log("inboxAddr", inboxAddr)
+    await sendL2DelayedTransaction(argv, argv.l1url, argv.l2url, inboxAddr);
   },
 };
 

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -22,6 +22,7 @@ import {
   setValidKeysetCommand,
   waitForSyncCommand,
   transferL3ChainOwnershipCommand,
+  sendL2DelayedCommand,
 } from "./ethcommands";
 
 async function main() {
@@ -52,6 +53,7 @@ async function main() {
     .command(transferERC20Command)
     .command(sendL1Command)
     .command(sendL2Command)
+    .command(sendL2DelayedCommand)
     .command(sendL3Command)
     .command(sendRPCCommand)
     .command(setValidKeysetCommand)

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -2,7 +2,7 @@ import { hideBin } from "yargs/helpers";
 import Yargs from "yargs/yargs";
 import { stressOptions } from "./stress";
 import { redisReadCommand, redisInitCommand } from "./redis";
-import { writeConfigCommand, writeGethGenesisCommand, writePrysmCommand, writeL2ChainConfigCommand, writeL3ChainConfigCommand, writeL2DASCommitteeConfigCommand, writeL2DASMirrorConfigCommand, writeL2DASKeysetConfigCommand } from "./config";
+import { writeConfigCommand, writeGethGenesisCommand, writePrysmCommand, writeL2ChainConfigCommand, writeL3ChainConfigCommand, writeL2DASCommitteeConfigCommand, writeL2DASMirrorConfigCommand, writeL2DASKeysetConfigCommand, updateConfigValueCommand } from "./config";
 import {
   printAddressCommand,
   namedAccountHelpString,
@@ -58,6 +58,7 @@ async function main() {
     .command(sendRPCCommand)
     .command(setValidKeysetCommand)
     .command(transferL3ChainOwnershipCommand)
+    .command(updateConfigValueCommand)
     .command(writeConfigCommand)
     .command(writeGethGenesisCommand)
     .command(writeL2ChainConfigCommand)


### PR DESCRIPTION
### This PR:
- Adds several commands in script for testing purpose
    - A command that sends delayed transaction
    - A command that update the config value
- Adds an endpoint in `mock-sequencer` to monitor delayed messages and empty their content
- Adds a test script to test
    - the caff node will fetch fetched delayed messages from L1. This is tested because mock sequencer will only give empty messages
    - the caff node will wait for confirmation blocks and finalization