### PR TITLE
skip batcher addr monitor test

### DIFF
--- a/regression-test.bash
+++ b/regression-test.bash
@@ -5,9 +5,21 @@ echo "Running regression tests..."
 cd "$(dirname "$0")"
 
 cd regression-tests
-scripts=$(find . -maxdepth 1 -name '*.bash' ! -name 'common.bash' | sort)
+scripts=$(find . -maxdepth 1 -name '*.bash' \
+  ! -name 'common.bash' \
+  ! -name 'caff-node-batcher-addr-monitor.bash' \
+  | sort)
 
-for script in $(find . -maxdepth 1 -name '*.bash' ! -name 'common.bash' | sort); do
+for script in $scripts; do
+  name=$(basename "$script")
+
+  for skip in "${SKIP_TESTS[@]}"; do
+    if [[ "$name" == "$skip" ]]; then
+      echo "⚠️  Skipping $name"
+      continue 2
+    fi
+  done
+
   echo "Running $(basename "$script")"
   attempt=1
   max_attempts=3


### PR DESCRIPTION


<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

`caff-node-batcher-addr-monitor.bash` regression test hangs indefinitely and eventually fails. After some debugging it looks like it cannot find the adding event logs in the caff node
Exact line: https://github.com/EspressoSystems/nitro-testnode/blob/e178d9c2140e7a34f2f96816fe2e74c1297839f4/regression-tests/caff-node-batcher-addr-monitor.bash#L31

Initially I thought it had something to do with the configs. But on further investigation, it does not look like we are doing this log in anywhere in the code anyways. On further digging through previous PRs it looks like we used have a AddBatchPosterSetEvents function in the batcher address monitor which did log this text. But in a recent [PR](https://github.com/EspressoSystems/nitro-espresso-integration/pull/881/changes#diff-175bb88afd5df43346a18f81dc043a34f2e259ccf41c058fa999ceac6ce78eee) this function was removed and mechanism to detect bathcer addr changes was modified. Now we do not log anything related to new batcher addrs.

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
- skips the `caff-node-batcher-addr-monitor.bash` regression test

