### PR TITLE
Use linux/amd64 for rollupcreator

### DIFF
--- a/rollupcreator/Dockerfile
+++ b/rollupcreator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim
+FROM --platform=linux/amd64 node:20-bookworm-slim
 ARG NITRO_CONTRACTS_BRANCH=main
 ARG NITRO_CONTRACTS_REPO=https://github.com/OffchainLabs/nitro-contracts.git
 RUN apt-get update


### PR DESCRIPTION
### Summary

Fixes a build failure that only occurs when compiling contracts in Docker on macOS (especially Apple Silicon). The issue does not reproduce on CI or when running `yarn build:all` directly on macOS.

### Problem

When building contracts inside Docker on macOS, the compilation fails with a WebAssembly-related error:

```
Error: Command failed: /usr/local/bin/node /workspace/node_modules/hardhat/internal/solidity/compiler/solcjs-runner.js /root/.cache/hardhat-nodejs/compilers-v2/wasm/soljson-v0.8.25+commit.b61c2a91.js
RuntimeError: memory access out of bounds
    at wasm://wasm/053f8e02:wasm-function[911]:0x39b00
    at wasm://wasm/053f8e02:wasm-function[148]:0x2773
```

This issue is specific to the macOS + Docker environment:

* ✅ Works on macOS directly in the contracts repo (`yarn build:all`)
* ✅ Works in CI
* ❌ Fails in Docker on macOS

### Solution

Force the container to use the `linux/amd64` platform:

```dockerfile
FROM --platform=linux/amd64 node:22-bookworm-slim
```

This ensures:

* Consistent architecture with CI and expected binaries
* Avoidance of unintended fallback to WASM-based compilation
* Stable contract compilation

### Trade-offs

⚠️ This change significantly increases build time on macOS:

* Contract build now takes ~50 minutes
* Due to QEMU emulation (`amd64` on Apple Silicon)

This is a known trade-off for correctness and reproducibility.

### Notes

* This change only affects Docker builds on macOS
* CI behavior remains unchanged
* Local (non-Docker) builds remain unaffected


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214064277896564